### PR TITLE
[CC-20] Add server-rendered per-entry static routes for catechism/confession questions

### DIFF
--- a/components/ConfessionTextResult.jsx
+++ b/components/ConfessionTextResult.jsx
@@ -10,7 +10,7 @@ import Link from 'next/link';
 
 import { parseOsisBibleReference, getConfessionalAbbreviationId } from '../scripts/helpers';
 import { confessionIdsWithoutTitles } from '../dataMapping';
-import { generateLink, regexV2 } from '../helpers';
+import { generateLink, generateNavLink, regexV2 } from '../helpers';
 
 const baseUrl = 'https://api.esv.org/v3/passage/text';
 const getQueryParams = (bibleText) => queryString.stringify({
@@ -196,8 +196,8 @@ const ConfessionTextResult = ({
             }
           }}
           href={obj.direction > 0
-            ? generateLink(nextConfessionId)
-            : generateLink(prevConfessionId)}
+            ? generateNavLink(nextConfessionId, contentById)
+            : generateNavLink(prevConfessionId, contentById)}
         >
           {/* className={`relative ${obj.direction > 0 ? 'left-full' : 'right-full'}`}> */}
           {obj.direction > 0

--- a/components/DocumentResultGroup.jsx
+++ b/components/DocumentResultGroup.jsx
@@ -1,0 +1,107 @@
+/* eslint-disable react/prop-types */
+/* eslint-disable react/jsx-props-no-spreading */
+import React from 'react';
+import Link from 'next/link';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faMinus, faPlus } from '@fortawesome/free-solid-svg-icons';
+
+import { getConfessionalAbbreviationId } from '../scripts/helpers';
+import {
+  isChapter, groupContentByChapter, handleSortById, getConciseDocId,
+} from '../helpers';
+import ConfessionChapterResult from './ConfessionChapterResult';
+import ConfessionTextResult from './ConfessionTextResult';
+
+// Renders one document's worth of matched entries: a title/match-count header
+// with an expand/collapse toggle, and either a ConfessionChapterResult (when
+// the match is a whole chapter) or ConfessionTextResult (a single entry) per
+// result. Shared by the homepage search results and the per-entry pages, so
+// both surfaces stay visually and behaviorally identical.
+const DocumentResultGroup = ({
+  documentTitle,
+  results,
+  contentById,
+  showArticleNav,
+  showChapterNav,
+  searchTerms = [],
+  getResultSearchTerms = () => [],
+  collapsed,
+  setCollapsed,
+  isExpanded,
+  onToggleExpand,
+}) => {
+  const documentId = getConfessionalAbbreviationId(documentTitle);
+  const conciseDocId = getConciseDocId(documentTitle);
+  const groupedByChapter = groupContentByChapter(results);
+
+  return (
+    <li>
+      <h2 className="text-3xl lg:text-4xl w-full mb-24 flex flex-wrap text-center">
+        <Link href={{ pathname: '/', query: { search: conciseDocId } }}>
+          {documentTitle}
+        </Link>
+        <span className="text-xl lg:text-lg my-auto mx-auto 2xl:mt-0 2xl:ml-auto 2xl:mr-0">
+          {`${results.length} ${results.length === 1 ? 'MATCH' : 'MATCHES'}`}
+          <FontAwesomeIcon
+            className="ml-5 my-auto text-xl lg:text-lg cursor-pointer"
+            icon={isExpanded ? faMinus : faPlus}
+            onClick={onToggleExpand}
+          />
+        </span>
+      </h2>
+      {isExpanded && (
+        <ul className="relative mx-4">
+          {Object
+            .keys(groupedByChapter)
+            .sort((a, b) => handleSortById({ id: a }, { id: b }))
+            .filter((key) => key.includes(documentId))
+            .map((chapterId) => {
+              const isResultChapter = isChapter(chapterId, contentById);
+              if (isResultChapter) {
+                return (
+                  <ConfessionChapterResult
+                    docTitle={documentTitle}
+                    docId={conciseDocId}
+                    chapterId={chapterId.split('-')[1]}
+                    showNav={showChapterNav}
+                    title={contentById[chapterId].title}
+                    searchTerms={searchTerms}
+                    collapsedChapters={collapsed}
+                    setCollapsed={setCollapsed}
+                    data={groupedByChapter[chapterId]
+                      .filter((obj) => !obj.isParent)
+                      .map((obj) => ({
+                        ...obj,
+                        showNav: showArticleNav,
+                        searchTerms: getResultSearchTerms(obj),
+                        hideChapterTitle: true,
+                        hideDocumentTitle: true,
+                        setCollapsed,
+                      }))
+                      .sort(handleSortById)}
+                    contentById={contentById}
+                  />
+                );
+              }
+              return groupedByChapter[chapterId]
+                .map((obj) => (
+                  <ConfessionTextResult
+                    {...obj}
+                    chapterId={chapterId.split('-')[1]}
+                    docTitle={documentTitle}
+                    docId={conciseDocId}
+                    linkToChapter
+                    showNav={showArticleNav}
+                    searchTerms={getResultSearchTerms(obj)}
+                    contentById={contentById}
+                    hideDocumentTitle
+                  />
+                ));
+            })}
+        </ul>
+      )}
+    </li>
+  );
+};
+
+export default DocumentResultGroup;

--- a/components/SEO.jsx
+++ b/components/SEO.jsx
@@ -2,25 +2,31 @@
 import React from 'react';
 import Head from 'next/head';
 
-const desc = 'Confessional Christianity is a web app promoting the value of the historic creeds of the Protestant Tradition. Users can search through the confessions via key words, Scripture within an elegant user interface. Soli Deo Gloria. Luke 17:10';
+export const SITE_URL = 'https://confessionalchristianity.com';
+
+const defaultDescription = 'Confessional Christianity is a web app promoting the value of the historic creeds of the Protestant Tradition. Users can search through the confessions via key words, Scripture within an elegant user interface. Soli Deo Gloria. Luke 17:10';
 
 const SEO = ({
   title = 'Confessional Christianity',
   subTitle,
   query = null,
+  description = defaultDescription,
+  canonicalUrl = null,
 }) => (
   <Head>
     <title>{title}</title>
+    <meta name="description" content={description} />
     <meta property="og:title" content={title} key="title" />
-    <meta property="og:description" content={desc} />
+    <meta property="og:description" content={description} />
     <meta
       property="og:image"
-      content={`https://confessionalchristianity.com/api/og?subTitle=${subTitle}${query ? `&query=${query}` : ''}`}
+      content={`${SITE_URL}/api/og?subTitle=${encodeURIComponent(subTitle || title)}${query ? `&query=${encodeURIComponent(query)}` : ''}`}
     />
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:domain" value="confessionalchristianity.com" />
-    <meta property="twitter:image" content={`https://confessionalchristianity.com/api/og?subTitle=${subTitle}&query=${query}`} />
+    <meta property="twitter:image" content={`${SITE_URL}/api/og?subTitle=${encodeURIComponent(subTitle || title)}${query ? `&query=${encodeURIComponent(query)}` : ''}`} />
     <link rel="shortcut icon" href="/favicon.ico" />
+    {canonicalUrl && <link rel="canonical" href={canonicalUrl} />}
   </Head>
 );
 

--- a/dataMapping/index.js
+++ b/dataMapping/index.js
@@ -31,6 +31,20 @@ export const confessionPathByName = {
   'martin-luthers-95-theses': 'normalized-data/reformation/95-theses.json',
 };
 
+// maps each document's true canonical id (as it appears as the id prefix in
+// contentById, e.g. "WCoF-1-2") to the URL slug used for its per-entry pages.
+// Keep in sync with confessionPathByName above.
+export const slugByDocumentId = {
+  WCoF: 'westminster-confession-of-faith',
+  WLC: 'westminster-larger-catechism',
+  WSC: 'westminster-shorter-catechism',
+  HC: 'heidelberg-catechism',
+  CoD: 'canons-of-dort',
+  TBCoF: 'the-belgic-confession-of-faith',
+  TAoR: 'thirty-nine-articles-of-religion',
+  ML9t: 'martin-luthers-95-theses',
+};
+
 // canonical docIds in algolia 🤦
 export const parentIdByAbbreviation = {
   WCF: 'WCoF',

--- a/helpers/index.js
+++ b/helpers/index.js
@@ -385,3 +385,45 @@ export const sliceConfessionId = (str, fragmentNumber) => {
   const idAsArr = str.split('-');
   return idAsArr.slice(0, fragmentNumber).join('-');
 };
+
+const footnoteMarkerRegex = /\[[a-zA-Z0-9]+\]/g;
+
+// strips ESV/proof-text footnote markers (e.g. "[a]", "[12]") out of confession text
+export const stripFootnoteMarkers = (text = '') => text
+  .replace(footnoteMarkerRegex, '')
+  .replace(/\s+/g, ' ')
+  .trim();
+
+// produces a clean, length-bounded string suitable for a meta description
+export const truncateForMeta = (text = '', maxLength = 160) => {
+  const clean = stripFootnoteMarkers(text);
+  if (clean.length <= maxLength) return clean;
+  const truncated = clean.slice(0, maxLength);
+  const lastSpace = truncated.lastIndexOf(' ');
+  return `${truncated.slice(0, lastSpace > 0 ? lastSpace : maxLength)}…`;
+};
+
+// compares two entry ids (e.g. "WCoF-1-2", "CoD-1-articles-3") in document order,
+// comparing each dash-separated fragment numerically where possible
+export const compareEntryIds = (aId, bId) => {
+  const a = aId.split('-').slice(1);
+  const b = bId.split('-').slice(1);
+  const len = Math.max(a.length, b.length);
+  for (let i = 0; i < len; i += 1) {
+    const [av, bv] = [a[i], b[i]];
+    if (av === undefined) return -1;
+    if (bv === undefined) return 1;
+    const [aNum, bNum] = [Number(av), Number(bv)];
+    const [aIsNum, bIsNum] = [!Number.isNaN(aNum), !Number.isNaN(bNum)];
+    if (aIsNum && bIsNum) {
+      if (aNum !== bNum) return aNum - bNum;
+    } else if (av !== bv) {
+      return av < bv ? -1 : 1;
+    }
+  }
+  return 0;
+};
+
+// strips the leading "<documentId>-" prefix off an entry id and splits the
+// remainder into URL path segments, e.g. entryIdToPathSegments('CoD-1-articles-1', 'CoD') -> ['1', 'articles', '1']
+export const entryIdToPathSegments = (id, documentId) => id.slice(documentId.length + 1).split('-');

--- a/helpers/index.js
+++ b/helpers/index.js
@@ -403,27 +403,6 @@ export const truncateForMeta = (text = '', maxLength = 160) => {
   return `${truncated.slice(0, lastSpace > 0 ? lastSpace : maxLength)}…`;
 };
 
-// compares two entry ids (e.g. "WCoF-1-2", "CoD-1-articles-3") in document order,
-// comparing each dash-separated fragment numerically where possible
-export const compareEntryIds = (aId, bId) => {
-  const a = aId.split('-').slice(1);
-  const b = bId.split('-').slice(1);
-  const len = Math.max(a.length, b.length);
-  for (let i = 0; i < len; i += 1) {
-    const [av, bv] = [a[i], b[i]];
-    if (av === undefined) return -1;
-    if (bv === undefined) return 1;
-    const [aNum, bNum] = [Number(av), Number(bv)];
-    const [aIsNum, bIsNum] = [!Number.isNaN(aNum), !Number.isNaN(bNum)];
-    if (aIsNum && bIsNum) {
-      if (aNum !== bNum) return aNum - bNum;
-    } else if (av !== bv) {
-      return av < bv ? -1 : 1;
-    }
-  }
-  return 0;
-};
-
 // strips the leading "<documentId>-" prefix off an entry id and splits the
 // remainder into URL path segments, e.g. entryIdToPathSegments('CoD-1-articles-1', 'CoD') -> ['1', 'articles', '1']
 export const entryIdToPathSegments = (id, documentId) => id.slice(documentId.length + 1).split('-');

--- a/helpers/index.js
+++ b/helpers/index.js
@@ -5,6 +5,7 @@ import {
   excludedWordsInDocumentId,
   parentIdByAbbreviation,
   facetNamesByCanonicalDocId,
+  slugByDocumentId,
 } from '../dataMapping';
 import contentById from '../dataMapping/content-by-id.json';
 import { toOsis } from '../scripts/helpers';
@@ -65,6 +66,31 @@ export const generateLink = (confessionId) => {
       search: `${docId}.${chapterOrQuestion}.${article}`,
     },
   };
+};
+
+// resolves a confession id (e.g. "WCoF-1-2") to its canonical per-entry page
+// URL, e.g. "/westminster-confession-of-faith/1/2". Returns null when no
+// per-entry page exists for the id's document (id is malformed or belongs to
+// a document without per-entry pages, e.g. CfYC).
+export const generateCanonicalEntryLink = (confessionId) => {
+  const [id, ...rest] = confessionId.split('-');
+  const trueDocId = parentIdByAbbreviation[getCanonicalDocId(id)];
+  const slug = trueDocId && slugByDocumentId[trueDocId];
+  if (!slug || rest.length === 0) return null;
+  return `/${slug}/${rest.join('/')}`;
+};
+
+// prefers the canonical per-entry URL over generateLink's query-string
+// search link when the target id is a real leaf entry with its own static
+// page - this avoids a redundant client-side Algolia search just to move to
+// the contiguous next/previous entry, since the canonical page needs none.
+export const generateNavLink = (confessionId, contentById) => {
+  const target = contentById[confessionId];
+  if (target && !target.isParent) {
+    const canonicalHref = generateCanonicalEntryLink(confessionId);
+    if (canonicalHref) return canonicalHref;
+  }
+  return generateLink(confessionId);
 };
 
 /**

--- a/helpers/index.js
+++ b/helpers/index.js
@@ -403,6 +403,28 @@ export const truncateForMeta = (text = '', maxLength = 160) => {
   return `${truncated.slice(0, lastSpace > 0 ? lastSpace : maxLength)}…`;
 };
 
+// compares two entry ids (e.g. "WCoF-1-2", "CoD-1-articles-3") in document order,
+// comparing each dash-separated fragment numerically where possible. Used to
+// build a real, crawlable prev/next path across every entry in a document.
+export const compareEntryIds = (aId, bId) => {
+  const a = aId.split('-').slice(1);
+  const b = bId.split('-').slice(1);
+  const len = Math.max(a.length, b.length);
+  for (let i = 0; i < len; i += 1) {
+    const [av, bv] = [a[i], b[i]];
+    if (av === undefined) return -1;
+    if (bv === undefined) return 1;
+    const [aNum, bNum] = [Number(av), Number(bv)];
+    const [aIsNum, bIsNum] = [!Number.isNaN(aNum), !Number.isNaN(bNum)];
+    if (aIsNum && bIsNum) {
+      if (aNum !== bNum) return aNum - bNum;
+    } else if (av !== bv) {
+      return av < bv ? -1 : 1;
+    }
+  }
+  return 0;
+};
+
 // strips the leading "<documentId>-" prefix off an entry id and splits the
 // remainder into URL path segments, e.g. entryIdToPathSegments('CoD-1-articles-1', 'CoD') -> ['1', 'articles', '1']
 export const entryIdToPathSegments = (id, documentId) => id.slice(documentId.length + 1).split('-');

--- a/lib/confessionContent.js
+++ b/lib/confessionContent.js
@@ -1,0 +1,26 @@
+import path from 'path';
+import { promises } from 'fs';
+
+import { confessionPathByName } from '../dataMapping';
+
+// Loads a single confession/catechism's content from its normalized JSON file
+// and keys it by id, same shape as pages/[confession].jsx has always built inline.
+export const loadConfessionContent = async (slug) => {
+  const pathToConfession = confessionPathByName[slug];
+  if (!pathToConfession) return null;
+
+  const fileContents = await promises.readFile(path.join(process.cwd(), pathToConfession), 'utf8');
+  const parsed = JSON.parse(fileContents);
+  const contentById = parsed.content.reduce((asObj, obj) => ({
+    ...asObj,
+    [obj.id]: obj,
+  }), {});
+
+  // the canonical document id (e.g. WSC, WCoF) is derived from any entry
+  // whose parent is the document itself (parent has no dash).
+  const documentId = Object
+    .entries(contentById)
+    .find(([, v]) => v.parent.split('-').length === 1)[1].parent;
+
+  return { contentById, documentId };
+};

--- a/pages/[confession].jsx
+++ b/pages/[confession].jsx
@@ -1,41 +1,22 @@
 import React, { useState, useEffect } from 'react';
 import { capitalize } from 'lodash';
-import path from 'path';
-import { promises } from 'fs';
 
 import { confessionPathByName, confessionIdsWithoutTitles } from '../dataMapping';
 import { isChapter } from '../helpers';
+import { loadConfessionContent } from '../lib/confessionContent';
 import ConfessionChapterResult from '../components/ConfessionChapterResult';
 import ConfessionTextResult from '../components/ConfessionTextResult';
 import Header from '../components/Header';
 import { track, EVENTS } from '../lib/analytics';
 
 export const getStaticProps = async (context) => {
-  const contentById = await Object
-    .entries(confessionPathByName)
-    .filter(([key]) => key === context.params.confession)
-    .reduce((prevPromise, [, value]) => prevPromise.then(async (acc) => {
-      const pathToConfession = path.join(process.cwd(), value);
-      const fileContents = await promises.readFile(pathToConfession, 'utf8');
-      const parsed = JSON.parse(fileContents);
-      const asObject = parsed.content
-        .reduce((asObj, obj) => ({
-          ...asObj,
-          [obj.id]: obj,
-        }), {});
-      return Promise.resolve({
-        ...acc,
-        ...asObject,
-      });
-    }), Promise.resolve({}));
+  const { contentById, documentId } = await loadConfessionContent(context.params.confession);
 
   return {
     props: {
       contentById,
       title: capitalize(context.params.confession.split('-').join(' ')),
-      documentId: Object
-        .entries(contentById)
-        .find(([k, v]) => v.parent.split('-').length === 1)[1].parent,
+      documentId,
     },
   };
 };

--- a/pages/[confession].jsx
+++ b/pages/[confession].jsx
@@ -2,21 +2,26 @@ import React, { useState, useEffect } from 'react';
 import { capitalize } from 'lodash';
 
 import { confessionPathByName, confessionIdsWithoutTitles } from '../dataMapping';
-import { isChapter } from '../helpers';
+import { isChapter, truncateForMeta } from '../helpers';
 import { loadConfessionContent } from '../lib/confessionContent';
 import ConfessionChapterResult from '../components/ConfessionChapterResult';
 import ConfessionTextResult from '../components/ConfessionTextResult';
 import Header from '../components/Header';
+import SEO, { SITE_URL } from '../components/SEO';
 import { track, EVENTS } from '../lib/analytics';
 
 export const getStaticProps = async (context) => {
   const { contentById, documentId } = await loadConfessionContent(context.params.confession);
+  const title = capitalize(context.params.confession.split('-').join(' '));
+  const firstEntry = Object.values(contentById).find((v) => !v.isParent);
 
   return {
     props: {
       contentById,
-      title: capitalize(context.params.confession.split('-').join(' ')),
+      title,
       documentId,
+      description: firstEntry ? truncateForMeta(firstEntry.text) : null,
+      canonicalUrl: `${SITE_URL}/${context.params.confession}`,
     },
   };
 };
@@ -33,6 +38,8 @@ const Confession = ({
   title,
   contentById,
   documentId,
+  description,
+  canonicalUrl,
 }) => {
   const [collapsed, setCollapsed] = useState({});
 
@@ -103,6 +110,7 @@ const Confession = ({
 
   return (
     <div className="home flex flex-col w-full">
+      <SEO title={`${title} | Confessional Christianity`} description={description} canonicalUrl={canonicalUrl} />
       <Header />
       <div className="p-8 my-12">
         <h2 className="text-3xl lg:text-4xl my-12 flex flex-wrap justify-center w-full lg:w-1/2 mx-auto">{title}</h2>

--- a/pages/[confession]/[...entry].jsx
+++ b/pages/[confession]/[...entry].jsx
@@ -12,7 +12,6 @@ import {
   truncateForMeta,
 } from '../../helpers';
 import Header from '../../components/Header';
-import Footer from '../../components/Footer';
 import ConfessionTextResult from '../../components/ConfessionTextResult';
 import SEO, { SITE_URL } from '../../components/SEO';
 import { track, EVENTS } from '../../lib/analytics';
@@ -104,15 +103,15 @@ const ConfessionEntry = ({
       />
       <Header />
       <div className="p-8 my-12">
-        <Link href={`/${slug}`}>
-          <span className="cursor-pointer block text-center uppercase tracking-widest text-sm mb-12">
-            {documentTitle}
-          </span>
-        </Link>
+        <h2 className="text-3xl lg:text-4xl my-12 flex flex-wrap justify-center w-full lg:w-1/2 mx-auto">
+          <Link href={`/${slug}`}>
+            <span className="cursor-pointer">{documentTitle}</span>
+          </Link>
+        </h2>
         {parentTitle && (
-          <h3 className="text-3xl lg:text-4xl w-full text-center mb-12">{parentTitle}</h3>
+          <h3 className="text-3xl lg:text-4xl w-full text-center mb-24">{parentTitle}</h3>
         )}
-        <ul className="results w-full lg:w-1/2 mx-auto">
+        <ul className="results w-full lg:w-1/2 mx-auto relative">
           <ConfessionTextResult
             {...item}
             docId={documentId}
@@ -122,28 +121,21 @@ const ConfessionEntry = ({
             showNav={false}
             hideChapterTitle
           />
+          {prevHref && (
+            <li className="absolute top-2 right-full">
+              <Link scroll={false} className="text-md p-4" href={prevHref}>
+                <FontAwesomeIcon className="cursor-pointer" icon={faChevronLeft} />
+              </Link>
+            </li>
+          )}
+          {nextHref && (
+            <li className="absolute top-2 left-full">
+              <Link scroll={false} className="text-md p-4" href={nextHref}>
+                <FontAwesomeIcon className="cursor-pointer" icon={faChevronRight} />
+              </Link>
+            </li>
+          )}
         </ul>
-        {(prevHref || nextHref) && (
-          <nav className="flex justify-between w-full lg:w-1/2 mx-auto mt-12">
-            {prevHref ? (
-              <Link href={prevHref}>
-                <span className="cursor-pointer">
-                  <FontAwesomeIcon icon={faChevronLeft} className="mr-2" />
-                  Previous
-                </span>
-              </Link>
-            ) : <span />}
-            {nextHref ? (
-              <Link href={nextHref}>
-                <span className="cursor-pointer">
-                  Next
-                  <FontAwesomeIcon icon={faChevronRight} className="ml-2" />
-                </span>
-              </Link>
-            ) : <span />}
-          </nav>
-        )}
-        <Footer />
       </div>
     </div>
   );

--- a/pages/[confession]/[...entry].jsx
+++ b/pages/[confession]/[...entry].jsx
@@ -1,0 +1,152 @@
+import React, { useEffect } from 'react';
+import { capitalize } from 'lodash';
+import Link from 'next/link';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
+
+import { confessionPathByName } from '../../dataMapping';
+import { loadConfessionContent } from '../../lib/confessionContent';
+import {
+  compareEntryIds,
+  entryIdToPathSegments,
+  truncateForMeta,
+} from '../../helpers';
+import Header from '../../components/Header';
+import Footer from '../../components/Footer';
+import ConfessionTextResult from '../../components/ConfessionTextResult';
+import SEO, { SITE_URL } from '../../components/SEO';
+import { track, EVENTS } from '../../lib/analytics';
+
+export const getStaticPaths = async () => {
+  const paths = (await Promise.all(
+    Object.keys(confessionPathByName).map(async (slug) => {
+      const { contentById, documentId } = await loadConfessionContent(slug);
+      return Object
+        .values(contentById)
+        .filter((item) => !item.isParent)
+        .map((item) => ({
+          params: {
+            confession: slug,
+            entry: entryIdToPathSegments(item.id, documentId),
+          },
+        }));
+    }),
+  )).flat();
+
+  return { paths, fallback: false };
+};
+
+export const getStaticProps = async (context) => {
+  const { confession: slug, entry } = context.params;
+  const { contentById, documentId } = await loadConfessionContent(slug);
+  const id = `${documentId}-${entry.join('-')}`;
+  const item = contentById[id];
+
+  if (!item) return { notFound: true };
+
+  const documentTitle = capitalize(slug.split('-').join(' '));
+  const parentEntry = contentById[item.parent];
+
+  const leafIds = Object
+    .values(contentById)
+    .filter((v) => !v.isParent)
+    .map((v) => v.id)
+    .sort(compareEntryIds);
+  const currentIndex = leafIds.indexOf(id);
+  const prevId = currentIndex > 0 ? leafIds[currentIndex - 1] : null;
+  const nextId = currentIndex < leafIds.length - 1 ? leafIds[currentIndex + 1] : null;
+
+  const toHref = (entryId) => `/${slug}/${entryIdToPathSegments(entryId, documentId).join('/')}`;
+
+  return {
+    props: {
+      slug,
+      documentId,
+      documentTitle,
+      item,
+      parentTitle: parentEntry ? parentEntry.title : null,
+      canonicalUrl: `${SITE_URL}/${slug}/${entry.join('/')}`,
+      description: truncateForMeta(item.text),
+      prevHref: prevId ? toHref(prevId) : null,
+      nextHref: nextId ? toHref(nextId) : null,
+    },
+  };
+};
+
+const ConfessionEntry = ({
+  slug,
+  documentId,
+  documentTitle,
+  item,
+  parentTitle,
+  canonicalUrl,
+  description,
+  prevHref,
+  nextHref,
+}) => {
+  useEffect(() => {
+    track(EVENTS.CONFESSION_VIEWED, {
+      confession_id: documentId,
+      confession_title: documentTitle,
+      entry_id: item.id,
+      entry_title: item.title,
+    });
+  }, [documentId, documentTitle, item.id, item.title]);
+
+  return (
+    <div className="home flex flex-col w-full">
+      <SEO
+        title={`${item.title} | ${documentTitle}`}
+        description={description}
+        canonicalUrl={canonicalUrl}
+        subTitle={item.title}
+        query={documentTitle}
+      />
+      <Header />
+      <div className="p-8 my-12">
+        <Link href={`/${slug}`}>
+          <span className="cursor-pointer block text-center uppercase tracking-widest text-sm mb-12">
+            {documentTitle}
+          </span>
+        </Link>
+        {parentTitle && (
+          <h3 className="text-3xl lg:text-4xl w-full text-center mb-12">{parentTitle}</h3>
+        )}
+        <ul className="results w-full lg:w-1/2 mx-auto">
+          <ConfessionTextResult
+            {...item}
+            docId={documentId}
+            docTitle={documentTitle}
+            contentById={{}}
+            searchTerms={[]}
+            showNav={false}
+            hideChapterTitle
+          />
+        </ul>
+        {(prevHref || nextHref) && (
+          <nav className="flex justify-between w-full lg:w-1/2 mx-auto mt-12">
+            {prevHref ? (
+              <Link href={prevHref}>
+                <span className="cursor-pointer">
+                  <FontAwesomeIcon icon={faChevronLeft} className="mr-2" />
+                  Previous
+                </span>
+              </Link>
+            ) : <span />}
+            {nextHref ? (
+              <Link href={nextHref}>
+                <span className="cursor-pointer">
+                  Next
+                  <FontAwesomeIcon icon={faChevronRight} className="ml-2" />
+                </span>
+              </Link>
+            ) : <span />}
+          </nav>
+        )}
+        <Footer />
+      </div>
+    </div>
+  );
+};
+
+export default ConfessionEntry;

--- a/pages/[confession]/[...entry].jsx
+++ b/pages/[confession]/[...entry].jsx
@@ -1,12 +1,16 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { capitalize } from 'lodash';
 import Link from 'next/link';
+import { useRouter } from 'next/router';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faTimes } from '@fortawesome/free-solid-svg-icons';
 
-import { confessionPathByName } from '../../dataMapping';
+import { confessionPathByName, confessionCitationByIndex } from '../../dataMapping';
 import { loadConfessionContent } from '../../lib/confessionContent';
 import { entryIdToPathSegments, truncateForMeta } from '../../helpers';
 import Header from '../../components/Header';
-import ConfessionTextResult from '../../components/ConfessionTextResult';
+import Footer from '../../components/Footer';
+import DocumentResultGroup from '../../components/DocumentResultGroup';
 import SEO, { SITE_URL } from '../../components/SEO';
 import { track, EVENTS } from '../../lib/analytics';
 
@@ -37,26 +41,18 @@ export const getStaticProps = async (context) => {
 
   if (!item) return { notFound: true };
 
-  const documentTitle = capitalize(slug.split('-').join(' '));
-  const parentEntry = contentById[item.parent];
-
-  // ConfessionTextResult's own prev/next nav only ever looks up
-  // `${documentId}-${secondFragment +/- 1}` (see getNextConfessionId), so
-  // only ship those two lookup keys instead of the whole document's content.
-  const [, chapterOrNumber] = id.split('-');
-  const neighborContentById = [1, -1].reduce((acc, offset) => {
-    const neighborId = `${documentId}-${Number(chapterOrNumber) + offset}`;
-    return contentById[neighborId] ? { ...acc, [neighborId]: true } : acc;
-  }, {});
+  const slugTitle = capitalize(slug.split('-').join(' '));
+  // full canonical title (e.g. "Westminster Shorter Catechism") - matches
+  // the same string DocumentResultGroup/Algolia results key off of.
+  const documentTitle = confessionCitationByIndex[documentId.toUpperCase()][0];
 
   return {
     props: {
       slug,
-      documentId,
+      slugTitle,
       documentTitle,
-      contentById: neighborContentById,
+      contentById,
       item,
-      parentTitle: parentEntry ? parentEntry.title : null,
       canonicalUrl: `${SITE_URL}/${slug}/${entry.join('/')}`,
       description: truncateForMeta(item.text),
     },
@@ -65,53 +61,94 @@ export const getStaticProps = async (context) => {
 
 const ConfessionEntry = ({
   slug,
-  documentId,
+  slugTitle,
   documentTitle,
   contentById,
   item,
-  parentTitle,
   canonicalUrl,
   description,
 }) => {
+  const router = useRouter();
+  const [searchTerm, setSearchTerm] = useState('');
+  const [collapsed, setCollapsed] = useState({});
+  const [isExpanded, setIsExpanded] = useState(true);
+
   useEffect(() => {
     track(EVENTS.CONFESSION_VIEWED, {
-      confession_id: documentId,
-      confession_title: documentTitle,
+      confession_id: documentTitle,
+      confession_title: slugTitle,
       entry_id: item.id,
       entry_title: item.title,
     });
-  }, [documentId, documentTitle, item.id, item.title]);
+  }, [documentTitle, slugTitle, item.id, item.title]);
+
+  const submitSearch = () => {
+    track(EVENTS.SEARCH_PERFORMED, {
+      search_term: searchTerm,
+      term_length: searchTerm?.length || 0,
+    });
+    router.push({ pathname: '/', query: { search: searchTerm } });
+  };
+
+  const handleKeyDown = (e) => {
+    e.persist();
+    if (e.keyCode === 13) submitSearch();
+  };
+
+  const handleSearchInput = (e) => {
+    e.persist();
+    setSearchTerm(e.target.value);
+  };
+
+  const handleClearSearch = (e) => {
+    e.preventDefault();
+    setSearchTerm('');
+  };
 
   return (
     <div className="home flex flex-col w-full">
       <SEO
-        title={`${item.title} | ${documentTitle}`}
+        title={`${item.title} | ${slugTitle}`}
         description={description}
         canonicalUrl={canonicalUrl}
         subTitle={item.title}
-        query={documentTitle}
+        query={slugTitle}
       />
       <Header />
-      <div className="p-8 my-12">
-        <h2 className="text-3xl lg:text-4xl my-12 flex flex-wrap justify-center w-full lg:w-1/2 mx-auto">
-          <Link href={`/${slug}`}>
-            <span className="cursor-pointer">{documentTitle}</span>
-          </Link>
-        </h2>
-        {parentTitle && (
-          <h3 className="text-3xl lg:text-4xl w-full text-center mb-24">{parentTitle}</h3>
-        )}
+      <div className="p-8">
+        <Link href={{ pathname: '/', query: { search: '' } }}>
+          <h1 className="cursor-pointer text-center text-4xl lg:text-5xl mx-auto max-w-2xl">
+            Confessional Christianity
+          </h1>
+        </Link>
+        <div className="w-full lg:w-1/2 mt-24 mx-auto sticky top-0 pt-10 pb-5 z-10 bg-white">
+          <input
+            type="text"
+            className="home-pg-search border border-gray-500 rounded-full leading-10 outline-none w-full pl-12 pr-12 py-2 relative"
+            value={searchTerm}
+            onChange={handleSearchInput}
+            onKeyDown={handleKeyDown}
+          />
+          <button className="absolute home-pg-search-btn" onClick={submitSearch} type="submit" tabIndex={-1} />
+          <FontAwesomeIcon icon={faTimes} onClick={handleClearSearch} className="home-pg-clear-search absolute" tabIndex={-1} />
+        </div>
+        <span className="block w-full text-center mb-24">
+          SHOWING 1 of 1 TOTAL MATCHES
+        </span>
         <ul className="results w-full lg:w-1/2 mx-auto">
-          <ConfessionTextResult
-            {...item}
-            docId={documentId}
-            docTitle={documentTitle}
+          <DocumentResultGroup
+            documentTitle={documentTitle}
+            results={[item]}
             contentById={contentById}
-            searchTerms={[]}
-            showNav
-            hideChapterTitle
+            showArticleNav
+            showChapterNav
+            collapsed={collapsed}
+            setCollapsed={setCollapsed}
+            isExpanded={isExpanded}
+            onToggleExpand={() => setIsExpanded(!isExpanded)}
           />
         </ul>
+        <Footer />
       </div>
     </div>
   );

--- a/pages/[confession]/[...entry].jsx
+++ b/pages/[confession]/[...entry].jsx
@@ -1,16 +1,10 @@
 import React, { useEffect } from 'react';
 import { capitalize } from 'lodash';
 import Link from 'next/link';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 
 import { confessionPathByName } from '../../dataMapping';
 import { loadConfessionContent } from '../../lib/confessionContent';
-import {
-  compareEntryIds,
-  entryIdToPathSegments,
-  truncateForMeta,
-} from '../../helpers';
+import { entryIdToPathSegments, truncateForMeta } from '../../helpers';
 import Header from '../../components/Header';
 import ConfessionTextResult from '../../components/ConfessionTextResult';
 import SEO, { SITE_URL } from '../../components/SEO';
@@ -46,28 +40,25 @@ export const getStaticProps = async (context) => {
   const documentTitle = capitalize(slug.split('-').join(' '));
   const parentEntry = contentById[item.parent];
 
-  const leafIds = Object
-    .values(contentById)
-    .filter((v) => !v.isParent)
-    .map((v) => v.id)
-    .sort(compareEntryIds);
-  const currentIndex = leafIds.indexOf(id);
-  const prevId = currentIndex > 0 ? leafIds[currentIndex - 1] : null;
-  const nextId = currentIndex < leafIds.length - 1 ? leafIds[currentIndex + 1] : null;
-
-  const toHref = (entryId) => `/${slug}/${entryIdToPathSegments(entryId, documentId).join('/')}`;
+  // ConfessionTextResult's own prev/next nav only ever looks up
+  // `${documentId}-${secondFragment +/- 1}` (see getNextConfessionId), so
+  // only ship those two lookup keys instead of the whole document's content.
+  const [, chapterOrNumber] = id.split('-');
+  const neighborContentById = [1, -1].reduce((acc, offset) => {
+    const neighborId = `${documentId}-${Number(chapterOrNumber) + offset}`;
+    return contentById[neighborId] ? { ...acc, [neighborId]: true } : acc;
+  }, {});
 
   return {
     props: {
       slug,
       documentId,
       documentTitle,
+      contentById: neighborContentById,
       item,
       parentTitle: parentEntry ? parentEntry.title : null,
       canonicalUrl: `${SITE_URL}/${slug}/${entry.join('/')}`,
       description: truncateForMeta(item.text),
-      prevHref: prevId ? toHref(prevId) : null,
-      nextHref: nextId ? toHref(nextId) : null,
     },
   };
 };
@@ -76,12 +67,11 @@ const ConfessionEntry = ({
   slug,
   documentId,
   documentTitle,
+  contentById,
   item,
   parentTitle,
   canonicalUrl,
   description,
-  prevHref,
-  nextHref,
 }) => {
   useEffect(() => {
     track(EVENTS.CONFESSION_VIEWED, {
@@ -111,30 +101,16 @@ const ConfessionEntry = ({
         {parentTitle && (
           <h3 className="text-3xl lg:text-4xl w-full text-center mb-24">{parentTitle}</h3>
         )}
-        <ul className="results w-full lg:w-1/2 mx-auto relative">
+        <ul className="results w-full lg:w-1/2 mx-auto">
           <ConfessionTextResult
             {...item}
             docId={documentId}
             docTitle={documentTitle}
-            contentById={{}}
+            contentById={contentById}
             searchTerms={[]}
-            showNav={false}
+            showNav
             hideChapterTitle
           />
-          {prevHref && (
-            <li className="absolute top-2 right-full">
-              <Link scroll={false} className="text-md p-4" href={prevHref}>
-                <FontAwesomeIcon className="cursor-pointer" icon={faChevronLeft} />
-              </Link>
-            </li>
-          )}
-          {nextHref && (
-            <li className="absolute top-2 left-full">
-              <Link scroll={false} className="text-md p-4" href={nextHref}>
-                <FontAwesomeIcon className="cursor-pointer" icon={faChevronRight} />
-              </Link>
-            </li>
-          )}
         </ul>
       </div>
     </div>

--- a/pages/[confession]/[...entry].jsx
+++ b/pages/[confession]/[...entry].jsx
@@ -7,7 +7,7 @@ import { faTimes } from '@fortawesome/free-solid-svg-icons';
 
 import { confessionPathByName, confessionCitationByIndex } from '../../dataMapping';
 import { loadConfessionContent } from '../../lib/confessionContent';
-import { entryIdToPathSegments, truncateForMeta } from '../../helpers';
+import { compareEntryIds, entryIdToPathSegments, truncateForMeta } from '../../helpers';
 import Header from '../../components/Header';
 import Footer from '../../components/Footer';
 import DocumentResultGroup from '../../components/DocumentResultGroup';
@@ -46,6 +46,22 @@ export const getStaticProps = async (context) => {
   // the same string DocumentResultGroup/Algolia results key off of.
   const documentTitle = confessionCitationByIndex[documentId.toUpperCase()][0];
 
+  // A real, crawlable link to the adjacent entry in document order - not
+  // just the search-query-string nav ConfessionTextResult renders - so
+  // crawlers (and readers) have an actual path between every entry page.
+  const leafIds = Object
+    .values(contentById)
+    .filter((v) => !v.isParent)
+    .map((v) => v.id)
+    .sort(compareEntryIds);
+  const currentIndex = leafIds.indexOf(id);
+  const prevId = currentIndex > 0 ? leafIds[currentIndex - 1] : null;
+  const nextId = currentIndex < leafIds.length - 1 ? leafIds[currentIndex + 1] : null;
+  const toEntryLink = (entryId) => ({
+    href: `/${slug}/${entryIdToPathSegments(entryId, documentId).join('/')}`,
+    title: contentById[entryId].title,
+  });
+
   return {
     props: {
       slug,
@@ -55,6 +71,8 @@ export const getStaticProps = async (context) => {
       item,
       canonicalUrl: `${SITE_URL}/${slug}/${entry.join('/')}`,
       description: truncateForMeta(item.text),
+      prevEntry: prevId ? toEntryLink(prevId) : null,
+      nextEntry: nextId ? toEntryLink(nextId) : null,
     },
   };
 };
@@ -67,6 +85,8 @@ const ConfessionEntry = ({
   item,
   canonicalUrl,
   description,
+  prevEntry,
+  nextEntry,
 }) => {
   const router = useRouter();
   const [searchTerm, setSearchTerm] = useState('');
@@ -148,6 +168,24 @@ const ConfessionEntry = ({
             onToggleExpand={() => setIsExpanded(!isExpanded)}
           />
         </ul>
+        {(prevEntry || nextEntry) && (
+          <nav className="flex justify-between w-full lg:w-1/2 mx-auto mb-24">
+            {prevEntry ? (
+              <Link href={prevEntry.href}>
+                <span className="cursor-pointer text-sm">
+                  {`← ${prevEntry.title}`}
+                </span>
+              </Link>
+            ) : <span />}
+            {nextEntry ? (
+              <Link href={nextEntry.href}>
+                <span className="cursor-pointer text-sm">
+                  {`${nextEntry.title} →`}
+                </span>
+              </Link>
+            ) : <span />}
+          </nav>
+        )}
         <Footer />
       </div>
     </div>

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -12,27 +12,22 @@ import {
 } from 'lodash';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
-  faMinus, faPlus, faSpinner, faTimes,
+  faSpinner, faTimes,
 } from '@fortawesome/free-solid-svg-icons';
 
 import {
   DOCUMENTS_WITHOUT_ARTICLES,
 } from '../dataMapping';
 
-import ConfessionTextResult from '../components/ConfessionTextResult';
-import ConfessionChapterResult from '../components/ConfessionChapterResult';
 import BibleTextResult from '../components/BibleTextResult';
+import DocumentResultGroup from '../components/DocumentResultGroup';
 import SEO from '../components/SEO';
 import Footer from '../components/Footer';
 import Header from '../components/Header';
 import contentById from '../dataMapping/content-by-id.json';
 
 import {
-  handleSortById,
   parseFacets,
-  isChapter,
-  groupContentByChapter,
-  getConciseDocId,
   regexV2,
   keyWords,
   usePgTitle,
@@ -40,7 +35,6 @@ import {
   isFacetLength,
   bibleRegex,
 } from '../helpers';
-
 import { getConfessionalAbbreviationId } from '../scripts/helpers';
 import { track, EVENTS } from '../lib/analytics';
 
@@ -300,7 +294,6 @@ const HomePage = ({
         }
 
         const documentId = getConfessionalAbbreviationId(documentTitle);
-        const groupedByChapter = groupContentByChapter(results);
         const showArticleNav = (
           // wcf.1.2
           (regexV2.test(searchTerm) && isFacetLength(searchTerm, 3))
@@ -316,75 +309,19 @@ const HomePage = ({
 
         );
         return acc.concat([
-          <li>
-            <h2 className="text-3xl lg:text-4xl w-full mb-24 flex flex-wrap text-center">
-              <Link
-                href={{ pathname: '/', query: { search: getConciseDocId(documentTitle) } }}
-              >
-                {documentTitle}
-              </Link>
-              <span className="text-xl lg:text-lg my-auto mx-auto 2xl:mt-0 2xl:ml-auto 2xl:mr-0">
-                {`${results.length} ${results.length === 1 ? 'MATCH' : 'MATCHES'}`}
-                <FontAwesomeIcon
-                  className="ml-5 my-auto text-xl lg:text-lg cursor-pointer"
-                  icon={isExpanded ? faMinus : faPlus}
-                  onClick={() => handleExpand(documentId)}
-                />
-              </span>
-            </h2>
-            {isExpanded && (
-              <ul className="relative mx-4">
-                {Object
-                  .keys(groupedByChapter)
-                  .sort((a, b) => handleSortById({ id: a }, { id: b }))
-                  .filter((key) => key.includes(documentId))
-                  .map((chapterId) => {
-                    const isResultChapter = isChapter(chapterId, contentById);
-                    // No chapter results displayed.
-                    if (isResultChapter) {
-                      return (
-                        <ConfessionChapterResult
-                          docTitle={documentTitle}
-                          docId={getConciseDocId(documentTitle)}
-                          chapterId={chapterId.split('-')[1]}
-                          showNav={showChapterNav}
-                          title={contentById[chapterId].title}
-                          searchTerms={searchTerm.split(' ')}
-                          collapsedChapters={collapsed}
-                          setCollapsed={setCollapsed}
-                          data={groupedByChapter[chapterId]
-                            .filter((obj) => !obj.isParent)
-                            .map((obj) => ({
-                              ...obj,
-                              showNav: showArticleNav,
-                              searchTerms: getSearchTerms(obj, searchTerm),
-                              hideChapterTitle: true,
-                              hideDocumentTitle: true,
-                              setCollapsed,
-                            }))
-                            .sort(handleSortById)}
-                          contentById={contentById}
-                        />
-                      );
-                    }
-                    return groupedByChapter[chapterId]
-                      .map((obj) => (
-                        <ConfessionTextResult
-                          {...obj}
-                          chapterId={chapterId.split('-')[1]}
-                          docTitle={documentTitle}
-                          docId={getConciseDocId(documentTitle)}
-                          linkToChapter
-                          showNav={showArticleNav}
-                          searchTerms={getSearchTerms(obj, searchTerm)}
-                          contentById={contentById}
-                          hideDocumentTitle
-                        />
-                      ));
-                  })}
-              </ul>
-            )}
-          </li>,
+          <DocumentResultGroup
+            documentTitle={documentTitle}
+            results={results}
+            contentById={contentById}
+            showArticleNav={showArticleNav}
+            showChapterNav={showChapterNav}
+            searchTerms={searchTerm.split(' ')}
+            getResultSearchTerms={(obj) => getSearchTerms(obj, searchTerm)}
+            collapsed={collapsed}
+            setCollapsed={setCollapsed}
+            isExpanded={isExpanded}
+            onToggleExpand={() => handleExpand(documentId)}
+          />,
         ]);
       }, []);
     return (

--- a/pages/sitemap.xml.jsx
+++ b/pages/sitemap.xml.jsx
@@ -1,0 +1,36 @@
+import { confessionPathByName } from '../dataMapping';
+import { loadConfessionContent } from '../lib/confessionContent';
+import { entryIdToPathSegments } from '../helpers';
+import { SITE_URL } from '../components/SEO';
+
+const STATIC_PATHS = ['', 'about'];
+
+const buildUrlEntry = (path) => `  <url>\n    <loc>${SITE_URL}/${path}</loc>\n  </url>`;
+
+export const getServerSideProps = async ({ res }) => {
+  const slugs = Object.keys(confessionPathByName);
+
+  const entryPaths = (await Promise.all(
+    slugs.map(async (slug) => {
+      const { contentById, documentId } = await loadConfessionContent(slug);
+      return Object
+        .values(contentById)
+        .filter((item) => !item.isParent)
+        .map((item) => `${slug}/${entryIdToPathSegments(item.id, documentId).join('/')}`);
+    }),
+  )).flat();
+
+  const urls = [...STATIC_PATHS, ...slugs, ...entryPaths];
+
+  const sitemap = `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${urls.map(buildUrlEntry).join('\n')}\n</urlset>`;
+
+  res.setHeader('Content-Type', 'text/xml');
+  res.write(sitemap);
+  res.end();
+
+  return { props: {} };
+};
+
+const Sitemap = () => null;
+
+export default Sitemap;

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://confessionalchristianity.com/sitemap.xml


### PR DESCRIPTION
## Summary

Individual catechism questions and confession articles now have their own unique, indexable URLs (e.g. `/westminster-shorter-catechism/1`, `/westminster-confession-of-faith/1/2`, `/canons-of-dort/1/articles/1`), statically generated with the real content and unique SEO tags in the initial HTML — instead of only being reachable via the homepage's client-side `?search=` query string, whose content is fetched from Algolia after hydration and never appears in server-rendered HTML.

This closes [CC-20](https://linear.app/custom-voice-app/issue/CC-20), filed after the [CC-5](https://linear.app/custom-voice-app/issue/CC-5) audit found individual entries had no indexable URLs at all. It unblocks CC-6 (unique meta tags), CC-7 (commentary), and CC-9 (internal links), which all need a URL to attach their content to.

### New route: `pages/[confession]/[...entry].jsx`
- `getStaticPaths`/`getStaticProps` generate ~875 pages at build time across all 8 confessions/catechisms, each rendering the full question/article text server-side.
- Unique `<title>`, `<meta name="description">`, `og:description`, `og:image`, and `<link rel="canonical">` per entry.
- Renders the **same chrome and rendering code** the homepage search results already use for a single match (hero title, search box, "SHOWING 1 of 1 TOTAL MATCHES" line, chapter/article grouping, prev/next chevron nav) — not a lookalike reimplementation. See below.

### Making the new pages discoverable
Having a URL isn't enough — search engines need a way to *find* it. Two problems, two fixes:
- **No sitemap existed.** Added `pages/sitemap.xml.jsx` (lists the homepage, `/about`, all 8 document pages, and every entry page) and `public/robots.txt` pointing at it.
- **No internal links pointed at these URLs either** — the existing prev/next chevron nav (reused from `ConfessionTextResult`) always links via `generateLink()`'s query-string hrefs (`/?search=...`), so crawlers had no link path to the new canonical pages at all, sitemap or not. Added a second, real `<Link>`-based prev/next (using each adjacent entry's own title as anchor text) computed from actual document order, so every entry page links directly to its neighbors.

### Removed a redundant network call on the existing chevron nav (site-wide, not just new pages)
`ConfessionTextResult`'s own prev/next chevron - used on the live homepage at `/?search=WSC.1` today, and reused by the new entry pages - always linked via `generateLink()`'s query string, which re-triggers a live client-side Algolia search just to display the next/previous entry, even when that entry already has its own statically generated page with the content pre-rendered. Added `generateNavLink()`, which resolves to the entry's real canonical URL whenever the target is an actual leaf entry (falling back to the old query-string link for the coarser "jump to next chapter" nav, which has no per-chapter page). Verified via network inspection that clicking next/prev now only fetches the target page's static JSON — no Algolia request.

### Shared-code extraction (why the entry pages aren't a parallel implementation)
- **`components/DocumentResultGroup.jsx`** (new): pulled the per-document result-rendering block (title/match-count header with expand-collapse, plus the `ConfessionChapterResult`/`ConfessionTextResult` branching) out of `pages/index.jsx`'s `renderResults`. Pure refactor of the homepage — verified the live search page still behaves identically — so the entry pages can render results through the exact same component instead of duplicating that branching logic.
- **`lib/confessionContent.js`** (new): the per-document JSON loading/parsing logic, extracted out of `pages/[confession].jsx` so both that page and the new entry pages share one loader.
- **`components/SEO.jsx`**: added a real `meta name="description"` tag (previously missing entirely), a `description` prop (falls back to the old hardcoded copy so existing callers are unaffected), and a `canonicalUrl` prop that renders `<link rel="canonical">` — there was no canonical tag anywhere in the app before this.
- **`pages/[confession].jsx`** (existing per-document page): now renders `<SEO>` with a unique title/description/canonical — it previously rendered no title or meta tags at all.
- **`dataMapping/index.js`**: added `slugByDocumentId`, mapping each document's true canonical id to its URL slug (kept in sync with `confessionPathByName`).
- **`helpers/index.js`**: added `stripFootnoteMarkers`/`truncateForMeta` (clean meta descriptions from confession text), `entryIdToPathSegments` (turns a content id like `CoD-1-articles-1` into its URL segments), `compareEntryIds` (orders entries for the crawlable prev/next links), and `generateCanonicalEntryLink`/`generateNavLink` (resolve an entry id to its canonical URL when one exists).

### Known pre-existing issue surfaced (not introduced here)
While making the entry pages match the search-results view, found that `ConfessionChapterResult`'s chapter-title link wraps its own prev/next nav link, nesting one `<a>` inside another — reproducible today on the *live* homepage at `/?search=WCF.1.2`, unrelated to this change. Filed as [CC-21](https://linear.app/custom-voice-app/issue/CC-21) (tech-debt) rather than fixed here, since it's a pre-existing bug in a shared, already-shipped component.

## Test plan
- [x] `next build` succeeds, generating ~875 per-entry static pages plus `/sitemap.xml`, with no new page-data-size warnings beyond the one the document page already had
- [x] Verified via `curl` that entry text, `<title>`, `<link rel="canonical">`, and the new prev/next links are present in the raw server-rendered HTML (not just after client JS) for WSC (single-level), WCF (chapter+article), Canons of Dort (chapter+articles/rejections), and 95 Theses (single-level)
- [x] Verified `/sitemap.xml` and `/robots.txt` serve correctly and the sitemap includes every document and entry URL
- [x] Verified prev/next links correctly omit at document boundaries (first/last entry)
- [x] Verified a nonexistent entry path 404s
- [x] Verified the existing per-document page (`/westminster-shorter-catechism`) still renders correctly with all questions
- [x] Verified the live homepage search (`/?search=WSC.1`, `/?search=WCF.1.2`) still works identically after extracting `DocumentResultGroup`
- [x] Verified via network inspection that the article-level chevron nav on both `/?search=WSC.1` and `/?search=WCF.1.2` now points at canonical URLs and triggers no Algolia request on click, while the chapter-level nav correctly still falls back to the search link
- [x] Compared entry pages against their `/?search=` equivalents via DOM/text inspection — content, headers, and match-count chrome match
- [x] Checked browser console for regressions — only pre-existing React warnings already present on `master` (missing `key` props, and the nested-`<a>` issue tracked in CC-21)

## After merge
- Submit `https://confessionalchristianity.com/sitemap.xml` in Google Search Console and Bing Webmaster Tools (manual step, needs account access)

🤖 Generated with [Claude Code](https://claude.com/claude-code)