### PR TITLE
Add per-entry commentary posts with a /study index

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,9 @@ normalized-data/deduped-bible-verses.json
 compendium/
 
 supabase/.temp
+
+# test coverage output
+coverage/
+
+# typescript incremental build cache
+*.tsbuildinfo

--- a/components/Commentary.jsx
+++ b/components/Commentary.jsx
@@ -1,0 +1,45 @@
+/* eslint-disable react/prop-types */
+import React from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+
+// Element styling is applied here (rather than via a typography plugin) so
+// rendered markdown matches the app's manual-Tailwind styling elsewhere.
+const components = {
+  h2: ({ node, ...props }) => <h2 className="text-2xl lg:text-3xl mt-10 mb-3" {...props} />,
+  h3: ({ node, ...props }) => <h3 className="text-xl lg:text-2xl mt-8 mb-2" {...props} />,
+  p: ({ node, ...props }) => <p className="my-4 leading-relaxed" {...props} />,
+  ul: ({ node, ...props }) => <ul className="list-disc pl-6 my-4" {...props} />,
+  ol: ({ node, ...props }) => <ol className="list-decimal pl-6 my-4" {...props} />,
+  li: ({ node, ...props }) => <li className="my-1 leading-relaxed" {...props} />,
+  blockquote: ({ node, ...props }) => (
+    <blockquote className="border-l-4 pl-4 italic my-6 text-gray-700" {...props} />
+  ),
+  a: ({ node, ...props }) => <a className="underline" {...props} />,
+  strong: ({ node, ...props }) => <strong className="font-bold" {...props} />,
+  em: ({ node, ...props }) => <em className="italic" {...props} />,
+};
+
+const Commentary = ({ commentary }) => {
+  if (!commentary) return null;
+  const {
+    title, subtitle, author, date, body,
+  } = commentary;
+
+  return (
+    <article className="commentary w-full lg:w-1/2 mx-auto mb-24 pt-12 border-t">
+      {title && <h2 className="text-3xl lg:text-4xl mb-2">{title}</h2>}
+      {subtitle && <p className="text-xl text-gray-600 mb-2">{subtitle}</p>}
+      {(author || date) && (
+        <p className="text-sm text-gray-500 mb-8">
+          {[author, date].filter(Boolean).join(' · ')}
+        </p>
+      )}
+      <ReactMarkdown remarkPlugins={[remarkGfm]} components={components}>
+        {body}
+      </ReactMarkdown>
+    </article>
+  );
+};
+
+export default Commentary;

--- a/content/commentary/WSC-1.md
+++ b/content/commentary/WSC-1.md
@@ -1,0 +1,33 @@
+---
+title: Made for Glory and Joy
+subtitle: On the chief end of man
+author: Maxwell Kendall
+date: 2026-07-05
+---
+
+The very first question of the Shorter Catechism does not begin with sin, or law,
+or even with God in the abstract. It begins with **purpose** — the reason we exist
+at all. And its answer joins two words we rarely hold together: *glory* and *enjoy*.
+
+## Two ends that are one
+
+We often assume that giving God glory and enjoying ourselves pull in opposite
+directions — that worship is a duty we pay before we get to the things we actually
+like. The catechism refuses that split. Notice it says man's chief *end* (singular),
+not ends:
+
+> Man's chief end is to glorify God, **and** to enjoy him forever.
+
+To glorify God *is* to enjoy him, and to enjoy him *is* to glorify him. They are two
+descriptions of a single life rightly ordered toward its Maker.
+
+## Why this comes first
+
+- It frames every question that follows. Sin, salvation, and obedience only make
+  sense against the backdrop of what we were made for.
+- It is deeply personal. The catechism is not asking what humanity is *for* in
+  general, but what *you* are for.
+- It ends with *forever* — locating our purpose not merely in this life but in the
+  life to come.
+
+Everything else in the catechism is, in one sense, a footnote to this first line.

--- a/lib/commentary.js
+++ b/lib/commentary.js
@@ -1,0 +1,44 @@
+import path from 'path';
+import { promises as fs } from 'fs';
+import matter from 'gray-matter';
+
+const COMMENTARY_DIR = path.join(process.cwd(), 'content', 'commentary');
+
+const toDateString = (d) => {
+  if (!d) return null;
+  if (d instanceof Date) return d.toISOString().slice(0, 10);
+  return String(d);
+};
+
+// Loads the optional long-form commentary / blog post for a single entry id
+// (e.g. "WSC-1", "WCoF-1-2"). Returns null when no post exists for that entry,
+// so entries without commentary render exactly as before. Read at build time
+// via getStaticProps, so there are no serverless file-tracing concerns.
+export const loadCommentary = async (entryId) => {
+  try {
+    const raw = await fs.readFile(path.join(COMMENTARY_DIR, `${entryId}.md`), 'utf8');
+    const { data, content } = matter(raw);
+    return {
+      title: data.title || null,
+      subtitle: data.subtitle || null,
+      author: data.author || null,
+      date: toDateString(data.date),
+      body: content,
+    };
+  } catch (err) {
+    if (err.code === 'ENOENT') return null;
+    throw err;
+  }
+};
+
+// Returns the list of entry ids that have a commentary post, for building an
+// index/listing and (eventually) the sitemap.
+export const listCommentaryIds = async () => {
+  try {
+    const files = await fs.readdir(COMMENTARY_DIR);
+    return files.filter((f) => f.endsWith('.md')).map((f) => f.replace(/\.md$/, ''));
+  } catch (err) {
+    if (err.code === 'ENOENT') return [];
+    throw err;
+  }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "autoprefixer": "^10.2.5",
         "babel-eslint": "^10.1.0",
         "classnames": "^2.2.6",
+        "gray-matter": "^4.0.3",
         "isomorphic-fetch": "^3.0.0",
         "lodash": "^4.17.20",
         "next": "^13.0.2",
@@ -39,6 +40,8 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-highlight-words": "^0.18.0",
+        "react-markdown": "^8.0.7",
+        "remark-gfm": "^3.0.1",
         "sass": "^1.26.3",
         "tailwindcss": "^2.0.4"
       },
@@ -2489,6 +2492,7 @@
       "version": "18.0.25",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.25.tgz",
       "integrity": "sha512-xD6c0KDT4m7n9uD4ZHi02lzskaiqcBxf4zi+tXZY98a04wvc0hi/TcCPC2FOESZi51Nd7tlUeOJY8RofL799/g==",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -5053,6 +5057,18 @@
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
+    "node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -5396,6 +5412,21 @@
       "version": "4.2.10",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
       "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
+    },
+    "node_modules/gray-matter": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
+      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-yaml": "^3.13.1",
+        "kind-of": "^6.0.2",
+        "section-matter": "^1.0.0",
+        "strip-bom-string": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
     },
     "node_modules/has": {
       "version": "1.0.3",
@@ -5841,6 +5872,15 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
       "integrity": "sha512-yVChGzahRFvbkscn2MlwGismPO12i9+znNruC5gVEntG3qu0xQMzsGg/JFbrsqDOHtHFPci+V5aP5T9I+yeKqw==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7954,6 +7994,15 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/kleur": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
@@ -8144,6 +8193,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/mdast-util-definitions": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/mdast-util-definitions/-/mdast-util-definitions-5.1.1.tgz",
@@ -8156,6 +8215,34 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-2.2.2.tgz",
+      "integrity": "sha512-MTtdFRz/eMDHXzeK6W3dO7mXUlF82Gom4y0oOgvHhh/HXZAGvIQDUvQ0SuUx+j2tv44b8xTHOm8K/9OoRFnXKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^5.0.0",
+        "unist-util-visit-parents": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/mdast-util-from-markdown": {
@@ -8175,6 +8262,100 @@
         "micromark-util-types": "^1.0.0",
         "unist-util-stringify-position": "^3.0.0",
         "uvu": "^0.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-2.0.2.tgz",
+      "integrity": "sha512-qvZ608nBppZ4icQlhQQIAdc6S3Ffj9RGmzwUKUWuEICFnd1LVkN3EktF7ZHAgfcEdvZB5owU9tQgt99e2TlLjg==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^1.0.0",
+        "mdast-util-gfm-autolink-literal": "^1.0.0",
+        "mdast-util-gfm-footnote": "^1.0.0",
+        "mdast-util-gfm-strikethrough": "^1.0.0",
+        "mdast-util-gfm-table": "^1.0.0",
+        "mdast-util-gfm-task-list-item": "^1.0.0",
+        "mdast-util-to-markdown": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-1.0.3.tgz",
+      "integrity": "sha512-My8KJ57FYEy2W2LyNom4n3E7hKTuQk/0SES0u16tjA9Z3oFkF4RrC/hPAPgjlSpezsOvI8ObcXcElo92wn5IGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "ccount": "^2.0.0",
+        "mdast-util-find-and-replace": "^2.0.0",
+        "micromark-util-character": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-1.0.2.tgz",
+      "integrity": "sha512-56D19KOGbE00uKVj3sgIykpwKL179QsVFwx/DCW0u/0+URsryacI4MAdNJl0dh+u2PSsD9FtxPFbHCzJ78qJFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "mdast-util-to-markdown": "^1.3.0",
+        "micromark-util-normalize-identifier": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-1.0.3.tgz",
+      "integrity": "sha512-DAPhYzTYrRcXdMjUtUjKvW9z/FNAMTdU0ORyMcbmkwYNbKocDpdk+PX1L1dQgOID/+vVs1uBQ7ElrBQfZ0cuiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "mdast-util-to-markdown": "^1.3.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-1.0.7.tgz",
+      "integrity": "sha512-jjcpmNnQvrmN5Vx7y7lEc2iIOEytYv7rTvu+MeyAsSHTASGCCRA79Igg2uKssgOs1i1po8s3plW0sTu1wkkLGg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^1.0.0",
+        "mdast-util-to-markdown": "^1.3.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-1.0.2.tgz",
+      "integrity": "sha512-PFTA1gzfp1B1UaiJVyhJZA1rm0+Tzn690frc/L8vNX1Jop4STZgOE6bxUhnzdVSB+vm2GU1tIsuQcA9bxTQpMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "mdast-util-to-markdown": "^1.3.0"
       },
       "funding": {
         "type": "opencollective",
@@ -8378,6 +8559,127 @@
         "micromark-util-symbol": "^1.0.0",
         "micromark-util-types": "^1.0.1",
         "uvu": "^0.5.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-2.0.3.tgz",
+      "integrity": "sha512-vb9OoHqrhCmbRidQv/2+Bc6pkP0FrtlhurxZofvOEy5o8RtuuvTq+RQ1Vw5ZDNrVraQZu3HixESqbG+0iKk/MQ==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^1.0.0",
+        "micromark-extension-gfm-footnote": "^1.0.0",
+        "micromark-extension-gfm-strikethrough": "^1.0.0",
+        "micromark-extension-gfm-table": "^1.0.0",
+        "micromark-extension-gfm-tagfilter": "^1.0.0",
+        "micromark-extension-gfm-task-list-item": "^1.0.0",
+        "micromark-util-combine-extensions": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-1.0.5.tgz",
+      "integrity": "sha512-z3wJSLrDf8kRDOh2qBtoTRD53vJ+CWIyo7uyZuxf/JAbNJjiHsOpG1y5wxk8drtv3ETAHutCu6N3thkOOgueWg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-sanitize-uri": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-1.1.2.tgz",
+      "integrity": "sha512-Yxn7z7SxgyGWRNa4wzf8AhYYWNrwl5q1Z8ii+CSTTIqVkmGZF1CElX2JI8g5yGoM3GAman9/PVCUFUSJ0kB/8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-core-commonmark": "^1.0.0",
+        "micromark-factory-space": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-normalize-identifier": "^1.0.0",
+        "micromark-util-sanitize-uri": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0",
+        "uvu": "^0.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-1.0.7.tgz",
+      "integrity": "sha512-sX0FawVE1o3abGk3vRjOH50L5TTLr3b5XMqnP9YDRb34M0v5OoZhG+OHFz1OffZ9dlwgpTBKaT4XW/AsUVnSDw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^1.0.0",
+        "micromark-util-classify-character": "^1.0.0",
+        "micromark-util-resolve-all": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0",
+        "uvu": "^0.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-1.0.7.tgz",
+      "integrity": "sha512-3ZORTHtcSnMQEKtAOsBQ9/oHp9096pI/UvdPtN7ehKvrmZZ2+bbWhi0ln+I9drmwXMt5boocn6OlwQzNXeVeqw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0",
+        "uvu": "^0.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-1.0.2.tgz",
+      "integrity": "sha512-5XWB9GbAUSHTn8VPU8/1DBXMuKYT5uOgEjJb8gN3mW0PNW5OPHpSdojoqf+iq1xo7vWzw/P8bAHY0n6ijpXF7g==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-1.0.5.tgz",
+      "integrity": "sha512-RMFXl2uQ0pNQy6Lun2YBYT9g9INXtWJULgbt01D/x8/6yJ2qpKyzdZD3pi6UIkzF++Da49xAelVKUeUMqd5eIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0",
+        "uvu": "^0.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/micromark-extension-mdx-expression": {
@@ -10046,6 +10348,52 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
+    "node_modules/react-markdown": {
+      "version": "8.0.7",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-8.0.7.tgz",
+      "integrity": "sha512-bvWbzG4MtOU62XqBx3Xx+zB2raaFFsq4mYiAzfjXJMEz2sixgeAfraA3tvzULF02ZdOMUOKTBFFaZJDDrq+BJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^2.0.0",
+        "@types/prop-types": "^15.0.0",
+        "@types/unist": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^2.0.0",
+        "prop-types": "^15.0.0",
+        "property-information": "^6.0.0",
+        "react-is": "^18.0.0",
+        "remark-parse": "^10.0.0",
+        "remark-rehype": "^10.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-object": "^0.4.0",
+        "unified": "^10.0.0",
+        "unist-util-visit": "^4.0.0",
+        "vfile": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16",
+        "react": ">=16"
+      }
+    },
+    "node_modules/react-markdown/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT"
+    },
+    "node_modules/react-markdown/node_modules/style-to-object": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-0.4.4.tgz",
+      "integrity": "sha512-HYNoHZa2GorYNyqiCaBgsxvcJIn7OHq6inEga+E6Ke3m5JkoqpQbnFssk4jwe+K7AhGa2fcha4wSOf1Kn01dMg==",
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.1.1"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -10121,6 +10469,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/mysticatea"
+      }
+    },
+    "node_modules/remark-gfm": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-3.0.1.tgz",
+      "integrity": "sha512-lEFDoi2PICJyNrACFOfDD3JlLkuSbOa5Wd8EPt06HUdptv8Gn0bxYTdbU/XXQ3swAPkEaGxxPN9cbnMHvVu1Ig==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "mdast-util-gfm": "^2.0.0",
+        "micromark-extension-gfm": "^2.0.0",
+        "unified": "^10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/remark-mdx": {
@@ -10397,6 +10761,19 @@
       },
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/section-matter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
+      "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/semver": {
@@ -10744,6 +11121,15 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/strip-bom-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+      "integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/strip-final-newline": {
@@ -13763,6 +14149,7 @@
       "version": "18.0.25",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.25.tgz",
       "integrity": "sha512-xD6c0KDT4m7n9uD4ZHi02lzskaiqcBxf4zi+tXZY98a04wvc0hi/TcCPC2FOESZi51Nd7tlUeOJY8RofL799/g==",
+      "peer": true,
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -15623,6 +16010,14 @@
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
+    "extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "requires": {
+        "is-extendable": "^0.1.0"
+      }
+    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -15865,6 +16260,17 @@
       "version": "4.2.10",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
       "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
+    },
+    "gray-matter": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
+      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
+      "requires": {
+        "js-yaml": "^3.13.1",
+        "kind-of": "^6.0.2",
+        "section-matter": "^1.0.0",
+        "strip-bom-string": "^1.0.0"
+      }
     },
     "has": {
       "version": "1.0.3",
@@ -16171,6 +16577,11 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
       "integrity": "sha512-yVChGzahRFvbkscn2MlwGismPO12i9+znNruC5gVEntG3qu0xQMzsGg/JFbrsqDOHtHFPci+V5aP5T9I+yeKqw=="
+    },
+    "is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw=="
     },
     "is-extglob": {
       "version": "2.1.1",
@@ -17631,6 +18042,11 @@
         "object.assign": "^4.1.3"
       }
     },
+    "kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
+    },
     "kleur": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
@@ -17772,6 +18188,11 @@
       "resolved": "https://registry.npmjs.org/markdown-extensions/-/markdown-extensions-1.1.1.tgz",
       "integrity": "sha512-WWC0ZuMzCyDHYCasEGs4IPvLyTGftYwh6wIEOULOF0HXcqZlhwRzrK0w2VUlxWA98xnvb/jszw4ZSkJ6ADpM6Q=="
     },
+    "markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw=="
+    },
     "mdast-util-definitions": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/mdast-util-definitions/-/mdast-util-definitions-5.1.1.tgz",
@@ -17780,6 +18201,24 @@
         "@types/mdast": "^3.0.0",
         "@types/unist": "^2.0.0",
         "unist-util-visit": "^4.0.0"
+      }
+    },
+    "mdast-util-find-and-replace": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-2.2.2.tgz",
+      "integrity": "sha512-MTtdFRz/eMDHXzeK6W3dO7mXUlF82Gom4y0oOgvHhh/HXZAGvIQDUvQ0SuUx+j2tv44b8xTHOm8K/9OoRFnXKw==",
+      "requires": {
+        "@types/mdast": "^3.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^5.0.0",
+        "unist-util-visit-parents": "^5.0.0"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+          "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="
+        }
       }
     },
     "mdast-util-from-markdown": {
@@ -17799,6 +18238,70 @@
         "micromark-util-types": "^1.0.0",
         "unist-util-stringify-position": "^3.0.0",
         "uvu": "^0.5.0"
+      }
+    },
+    "mdast-util-gfm": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-2.0.2.tgz",
+      "integrity": "sha512-qvZ608nBppZ4icQlhQQIAdc6S3Ffj9RGmzwUKUWuEICFnd1LVkN3EktF7ZHAgfcEdvZB5owU9tQgt99e2TlLjg==",
+      "requires": {
+        "mdast-util-from-markdown": "^1.0.0",
+        "mdast-util-gfm-autolink-literal": "^1.0.0",
+        "mdast-util-gfm-footnote": "^1.0.0",
+        "mdast-util-gfm-strikethrough": "^1.0.0",
+        "mdast-util-gfm-table": "^1.0.0",
+        "mdast-util-gfm-task-list-item": "^1.0.0",
+        "mdast-util-to-markdown": "^1.0.0"
+      }
+    },
+    "mdast-util-gfm-autolink-literal": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-1.0.3.tgz",
+      "integrity": "sha512-My8KJ57FYEy2W2LyNom4n3E7hKTuQk/0SES0u16tjA9Z3oFkF4RrC/hPAPgjlSpezsOvI8ObcXcElo92wn5IGA==",
+      "requires": {
+        "@types/mdast": "^3.0.0",
+        "ccount": "^2.0.0",
+        "mdast-util-find-and-replace": "^2.0.0",
+        "micromark-util-character": "^1.0.0"
+      }
+    },
+    "mdast-util-gfm-footnote": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-1.0.2.tgz",
+      "integrity": "sha512-56D19KOGbE00uKVj3sgIykpwKL179QsVFwx/DCW0u/0+URsryacI4MAdNJl0dh+u2PSsD9FtxPFbHCzJ78qJFQ==",
+      "requires": {
+        "@types/mdast": "^3.0.0",
+        "mdast-util-to-markdown": "^1.3.0",
+        "micromark-util-normalize-identifier": "^1.0.0"
+      }
+    },
+    "mdast-util-gfm-strikethrough": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-1.0.3.tgz",
+      "integrity": "sha512-DAPhYzTYrRcXdMjUtUjKvW9z/FNAMTdU0ORyMcbmkwYNbKocDpdk+PX1L1dQgOID/+vVs1uBQ7ElrBQfZ0cuiQ==",
+      "requires": {
+        "@types/mdast": "^3.0.0",
+        "mdast-util-to-markdown": "^1.3.0"
+      }
+    },
+    "mdast-util-gfm-table": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-1.0.7.tgz",
+      "integrity": "sha512-jjcpmNnQvrmN5Vx7y7lEc2iIOEytYv7rTvu+MeyAsSHTASGCCRA79Igg2uKssgOs1i1po8s3plW0sTu1wkkLGg==",
+      "requires": {
+        "@types/mdast": "^3.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^1.0.0",
+        "mdast-util-to-markdown": "^1.3.0"
+      }
+    },
+    "mdast-util-gfm-task-list-item": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-1.0.2.tgz",
+      "integrity": "sha512-PFTA1gzfp1B1UaiJVyhJZA1rm0+Tzn690frc/L8vNX1Jop4STZgOE6bxUhnzdVSB+vm2GU1tIsuQcA9bxTQpMQ==",
+      "requires": {
+        "@types/mdast": "^3.0.0",
+        "mdast-util-to-markdown": "^1.3.0"
       }
     },
     "mdast-util-mdx": {
@@ -17946,6 +18449,92 @@
         "micromark-util-subtokenize": "^1.0.0",
         "micromark-util-symbol": "^1.0.0",
         "micromark-util-types": "^1.0.1",
+        "uvu": "^0.5.0"
+      }
+    },
+    "micromark-extension-gfm": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-2.0.3.tgz",
+      "integrity": "sha512-vb9OoHqrhCmbRidQv/2+Bc6pkP0FrtlhurxZofvOEy5o8RtuuvTq+RQ1Vw5ZDNrVraQZu3HixESqbG+0iKk/MQ==",
+      "requires": {
+        "micromark-extension-gfm-autolink-literal": "^1.0.0",
+        "micromark-extension-gfm-footnote": "^1.0.0",
+        "micromark-extension-gfm-strikethrough": "^1.0.0",
+        "micromark-extension-gfm-table": "^1.0.0",
+        "micromark-extension-gfm-tagfilter": "^1.0.0",
+        "micromark-extension-gfm-task-list-item": "^1.0.0",
+        "micromark-util-combine-extensions": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "micromark-extension-gfm-autolink-literal": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-1.0.5.tgz",
+      "integrity": "sha512-z3wJSLrDf8kRDOh2qBtoTRD53vJ+CWIyo7uyZuxf/JAbNJjiHsOpG1y5wxk8drtv3ETAHutCu6N3thkOOgueWg==",
+      "requires": {
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-sanitize-uri": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "micromark-extension-gfm-footnote": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-1.1.2.tgz",
+      "integrity": "sha512-Yxn7z7SxgyGWRNa4wzf8AhYYWNrwl5q1Z8ii+CSTTIqVkmGZF1CElX2JI8g5yGoM3GAman9/PVCUFUSJ0kB/8Q==",
+      "requires": {
+        "micromark-core-commonmark": "^1.0.0",
+        "micromark-factory-space": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-normalize-identifier": "^1.0.0",
+        "micromark-util-sanitize-uri": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0",
+        "uvu": "^0.5.0"
+      }
+    },
+    "micromark-extension-gfm-strikethrough": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-1.0.7.tgz",
+      "integrity": "sha512-sX0FawVE1o3abGk3vRjOH50L5TTLr3b5XMqnP9YDRb34M0v5OoZhG+OHFz1OffZ9dlwgpTBKaT4XW/AsUVnSDw==",
+      "requires": {
+        "micromark-util-chunked": "^1.0.0",
+        "micromark-util-classify-character": "^1.0.0",
+        "micromark-util-resolve-all": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0",
+        "uvu": "^0.5.0"
+      }
+    },
+    "micromark-extension-gfm-table": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-1.0.7.tgz",
+      "integrity": "sha512-3ZORTHtcSnMQEKtAOsBQ9/oHp9096pI/UvdPtN7ehKvrmZZ2+bbWhi0ln+I9drmwXMt5boocn6OlwQzNXeVeqw==",
+      "requires": {
+        "micromark-factory-space": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0",
+        "uvu": "^0.5.0"
+      }
+    },
+    "micromark-extension-gfm-tagfilter": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-1.0.2.tgz",
+      "integrity": "sha512-5XWB9GbAUSHTn8VPU8/1DBXMuKYT5uOgEjJb8gN3mW0PNW5OPHpSdojoqf+iq1xo7vWzw/P8bAHY0n6ijpXF7g==",
+      "requires": {
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "micromark-extension-gfm-task-list-item": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-1.0.5.tgz",
+      "integrity": "sha512-RMFXl2uQ0pNQy6Lun2YBYT9g9INXtWJULgbt01D/x8/6yJ2qpKyzdZD3pi6UIkzF++Da49xAelVKUeUMqd5eIQ==",
+      "requires": {
+        "micromark-factory-space": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0",
         "uvu": "^0.5.0"
       }
     },
@@ -18980,6 +19569,43 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
+    "react-markdown": {
+      "version": "8.0.7",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-8.0.7.tgz",
+      "integrity": "sha512-bvWbzG4MtOU62XqBx3Xx+zB2raaFFsq4mYiAzfjXJMEz2sixgeAfraA3tvzULF02ZdOMUOKTBFFaZJDDrq+BJQ==",
+      "requires": {
+        "@types/hast": "^2.0.0",
+        "@types/prop-types": "^15.0.0",
+        "@types/unist": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^2.0.0",
+        "prop-types": "^15.0.0",
+        "property-information": "^6.0.0",
+        "react-is": "^18.0.0",
+        "remark-parse": "^10.0.0",
+        "remark-rehype": "^10.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-object": "^0.4.0",
+        "unified": "^10.0.0",
+        "unist-util-visit": "^4.0.0",
+        "vfile": "^5.0.0"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "18.3.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+          "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
+        },
+        "style-to-object": {
+          "version": "0.4.4",
+          "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-0.4.4.tgz",
+          "integrity": "sha512-HYNoHZa2GorYNyqiCaBgsxvcJIn7OHq6inEga+E6Ke3m5JkoqpQbnFssk4jwe+K7AhGa2fcha4wSOf1Kn01dMg==",
+          "requires": {
+            "inline-style-parser": "0.1.1"
+          }
+        }
+      }
+    },
     "read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -19039,6 +19665,17 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
       "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg=="
+    },
+    "remark-gfm": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-3.0.1.tgz",
+      "integrity": "sha512-lEFDoi2PICJyNrACFOfDD3JlLkuSbOa5Wd8EPt06HUdptv8Gn0bxYTdbU/XXQ3swAPkEaGxxPN9cbnMHvVu1Ig==",
+      "requires": {
+        "@types/mdast": "^3.0.0",
+        "mdast-util-gfm": "^2.0.0",
+        "micromark-extension-gfm": "^2.0.0",
+        "unified": "^10.0.0"
+      }
     },
     "remark-mdx": {
       "version": "2.1.5",
@@ -19222,6 +19859,15 @@
         "ajv": "^6.1.0",
         "ajv-errors": "^1.0.0",
         "ajv-keywords": "^3.1.0"
+      }
+    },
+    "section-matter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
+      "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
+      "requires": {
+        "extend-shallow": "^2.0.1",
+        "kind-of": "^6.0.0"
       }
     },
     "semver": {
@@ -19485,6 +20131,11 @@
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
       "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
       "dev": true
+    },
+    "strip-bom-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+      "integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g=="
     },
     "strip-final-newline": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "autoprefixer": "^10.2.5",
     "babel-eslint": "^10.1.0",
     "classnames": "^2.2.6",
+    "gray-matter": "^4.0.3",
     "isomorphic-fetch": "^3.0.0",
     "lodash": "^4.17.20",
     "next": "^13.0.2",
@@ -46,6 +47,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-highlight-words": "^0.18.0",
+    "react-markdown": "^8.0.7",
+    "remark-gfm": "^3.0.1",
     "sass": "^1.26.3",
     "tailwindcss": "^2.0.4"
   },

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "next -p 1517",
+    "new-post": "node scripts/new-post.js",
     "build": "next build",
     "prod": "next start",
     "db:migrate": "npx supabase db push",

--- a/pages/[confession]/[...entry].jsx
+++ b/pages/[confession]/[...entry].jsx
@@ -7,9 +7,11 @@ import { faTimes } from '@fortawesome/free-solid-svg-icons';
 
 import { confessionPathByName, confessionCitationByIndex } from '../../dataMapping';
 import { loadConfessionContent } from '../../lib/confessionContent';
+import { loadCommentary } from '../../lib/commentary';
 import { compareEntryIds, entryIdToPathSegments, truncateForMeta } from '../../helpers';
 import Header from '../../components/Header';
 import Footer from '../../components/Footer';
+import Commentary from '../../components/Commentary';
 import DocumentResultGroup from '../../components/DocumentResultGroup';
 import SEO, { SITE_URL } from '../../components/SEO';
 import { track, EVENTS } from '../../lib/analytics';
@@ -62,6 +64,8 @@ export const getStaticProps = async (context) => {
     title: contentById[entryId].title,
   });
 
+  const commentary = await loadCommentary(id);
+
   return {
     props: {
       slug,
@@ -70,9 +74,10 @@ export const getStaticProps = async (context) => {
       contentById,
       item,
       canonicalUrl: `${SITE_URL}/${slug}/${entry.join('/')}`,
-      description: truncateForMeta(item.text),
+      description: truncateForMeta((commentary && commentary.subtitle) || item.text),
       prevEntry: prevId ? toEntryLink(prevId) : null,
       nextEntry: nextId ? toEntryLink(nextId) : null,
+      commentary,
     },
   };
 };
@@ -87,6 +92,7 @@ const ConfessionEntry = ({
   description,
   prevEntry,
   nextEntry,
+  commentary,
 }) => {
   const router = useRouter();
   const [searchTerm, setSearchTerm] = useState('');
@@ -168,6 +174,7 @@ const ConfessionEntry = ({
             onToggleExpand={() => setIsExpanded(!isExpanded)}
           />
         </ul>
+        <Commentary commentary={commentary} />
         {(prevEntry || nextEntry) && (
           <nav className="flex justify-between w-full lg:w-1/2 mx-auto mb-24">
             {prevEntry ? (

--- a/pages/sitemap.xml.jsx
+++ b/pages/sitemap.xml.jsx
@@ -3,7 +3,7 @@ import { loadConfessionContent } from '../lib/confessionContent';
 import { entryIdToPathSegments } from '../helpers';
 import { SITE_URL } from '../components/SEO';
 
-const STATIC_PATHS = ['', 'about'];
+const STATIC_PATHS = ['', 'about', 'study'];
 
 const buildUrlEntry = (path) => `  <url>\n    <loc>${SITE_URL}/${path}</loc>\n  </url>`;
 

--- a/pages/study.jsx
+++ b/pages/study.jsx
@@ -1,0 +1,90 @@
+/* eslint-disable react/prop-types */
+import React from 'react';
+import Link from 'next/link';
+
+import { slugByDocumentId, confessionCitationByIndex } from '../dataMapping';
+import { entryIdToPathSegments } from '../helpers';
+import { loadConfessionContent } from '../lib/confessionContent';
+import { listCommentaryIds, loadCommentary } from '../lib/commentary';
+import Header from '../components/Header';
+import Footer from '../components/Footer';
+import SEO, { SITE_URL } from '../components/SEO';
+
+export const getStaticProps = async () => {
+  const ids = await listCommentaryIds();
+  const contentCache = {};
+  const posts = [];
+
+  // eslint-disable-next-line no-restricted-syntax
+  for (const id of ids) {
+    const documentId = id.split('-')[0];
+    const slug = slugByDocumentId[documentId];
+    if (!slug) continue; // ids we can't map to a per-entry page (skip)
+
+    // eslint-disable-next-line no-await-in-loop
+    const commentary = await loadCommentary(id);
+    if (!contentCache[slug]) {
+      // eslint-disable-next-line no-await-in-loop
+      contentCache[slug] = (await loadConfessionContent(slug)).contentById;
+    }
+    const entry = contentCache[slug][id];
+
+    posts.push({
+      id,
+      href: `/${slug}/${entryIdToPathSegments(id, documentId).join('/')}`,
+      title: commentary.title || (entry ? entry.title : id),
+      subtitle: commentary.subtitle,
+      date: commentary.date,
+      documentTitle: (confessionCitationByIndex[documentId.toUpperCase()] || [])[0] || slug,
+      entryTitle: entry ? entry.title : null,
+    });
+  }
+
+  // newest first; posts without a date sort last
+  posts.sort((a, b) => (b.date || '').localeCompare(a.date || ''));
+
+  return { props: { posts } };
+};
+
+const Study = ({ posts }) => (
+  <div className="home flex flex-col w-full">
+    <SEO
+      title="Study | Confessional Christianity"
+      description="Reflections and commentary on the historic creeds, confessions, and catechisms of the Protestant tradition."
+      canonicalUrl={`${SITE_URL}/study`}
+    />
+    <Header />
+    <div className="p-8">
+      <Link href={{ pathname: '/', query: { search: '' } }}>
+        <h1 className="cursor-pointer text-center text-4xl lg:text-5xl mx-auto max-w-2xl">
+          Confessional Christianity
+        </h1>
+      </Link>
+      <h2 className="text-3xl lg:text-4xl text-center my-16">Study</h2>
+      <ul className="results w-full lg:w-1/2 mx-auto">
+        {posts.length === 0 && (
+          <li className="text-center text-gray-500">No posts yet.</li>
+        )}
+        {posts.map((post) => (
+          <li key={post.id} className="mb-12 pb-12 border-b">
+            <Link href={post.href}>
+              <div className="cursor-pointer">
+                <h3 className="text-2xl lg:text-3xl mb-1">{post.title}</h3>
+                {post.subtitle && (
+                  <p className="text-lg text-gray-600 mb-2">{post.subtitle}</p>
+                )}
+                <p className="text-sm text-gray-500 uppercase tracking-wider">
+                  {[post.documentTitle, post.entryTitle].filter(Boolean).join(' · ')}
+                  {post.date ? ` · ${post.date}` : ''}
+                </p>
+              </div>
+            </Link>
+          </li>
+        ))}
+      </ul>
+      <Footer />
+    </div>
+  </div>
+);
+
+export default Study;

--- a/scripts/new-post.js
+++ b/scripts/new-post.js
@@ -1,0 +1,119 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+
+// Scaffolds a commentary post at content/commentary/<entry-id>.md, deriving the
+// (non-obvious) entry id from a reader-facing URL or slug + path segments.
+//
+// Usage:
+//   node scripts/new-post.js /westminster-shorter-catechism/1
+//   node scripts/new-post.js westminster-shorter-catechism 1
+//   node scripts/new-post.js westminster-confession-of-faith 1 2
+//   node scripts/new-post.js canons-of-dort 1 articles 1
+//   ...add --force to overwrite an existing file.
+
+import fs from 'fs';
+import path from 'path';
+import { execSync } from 'child_process';
+
+// slug -> normalized-data JSON file. Keep in sync with confessionPathByName in
+// dataMapping/index.js (that module is ESM, so it can't be required here).
+const confessionPathByName = {
+  'westminster-confession-of-faith': 'normalized-data/westminster/wcf.json',
+  'westminster-larger-catechism': 'normalized-data/westminster/wlc.json',
+  'westminster-shorter-catechism': 'normalized-data/westminster/wsc.json',
+  'heidelberg-catechism': 'normalized-data/three-forms-of-unity/heidelberg-catechism.json',
+  'canons-of-dort': 'normalized-data/three-forms-of-unity/canons-of-dort.json',
+  'the-belgic-confession-of-faith': 'normalized-data/three-forms-of-unity/belgic-confession.json',
+  'thirty-nine-articles-of-religion': 'normalized-data/anglican/39-articles.json',
+  'martin-luthers-95-theses': 'normalized-data/reformation/95-theses.json',
+};
+
+const fail = (msg) => {
+  console.error(`\n✖ ${msg}\n`);
+  process.exit(1);
+};
+
+// --- parse args -------------------------------------------------------------
+const rawArgs = process.argv.slice(2);
+const force = rawArgs.includes('--force');
+const args = rawArgs.filter((a) => a !== '--force');
+
+if (args.length === 0) {
+  fail('Provide a URL or slug + segments, e.g.\n'
+    + '    node scripts/new-post.js /westminster-shorter-catechism/1\n'
+    + '    node scripts/new-post.js westminster-confession-of-faith 1 2');
+}
+
+// Accept a full URL, a "/slug/1/2" path, or "slug 1 2" as separate args.
+let parts;
+if (args.length === 1 && args[0].includes('/')) {
+  const withoutProtocol = args[0].replace(/^https?:\/\/[^/]+/, '');
+  parts = withoutProtocol.split('/').filter(Boolean);
+} else {
+  parts = args;
+}
+
+const [slug, ...segments] = parts;
+
+if (!confessionPathByName[slug]) {
+  fail(`Unknown confession slug "${slug}".\nValid slugs:\n  ${Object.keys(confessionPathByName).join('\n  ')}`);
+}
+if (segments.length === 0) {
+  fail(`No entry segments given. Point at a specific entry, e.g. "${slug} 1".`);
+}
+
+// --- load the confession and resolve the entry id ---------------------------
+const jsonPath = path.join(process.cwd(), confessionPathByName[slug]);
+const parsed = JSON.parse(fs.readFileSync(jsonPath, 'utf8'));
+const contentById = parsed.content.reduce((acc, item) => ({ ...acc, [item.id]: item }), {});
+
+// documentId (e.g. WSC, WCoF) is the parent of any top-level entry.
+const documentId = parsed.content.find((v) => v.parent.split('-').length === 1).parent;
+const entryId = `${documentId}-${segments.join('-')}`;
+const entry = contentById[entryId];
+
+if (!entry) {
+  fail(`No entry "${entryId}" exists in ${slug}.\n`
+    + `Check the URL — segments were: ${segments.join(', ')}.`);
+}
+
+// --- write the scaffold -----------------------------------------------------
+const dir = path.join(process.cwd(), 'content', 'commentary');
+fs.mkdirSync(dir, { recursive: true });
+const filePath = path.join(dir, `${entryId}.md`);
+
+if (fs.existsSync(filePath) && !force) {
+  fail(`${path.relative(process.cwd(), filePath)} already exists. Re-run with --force to overwrite.`);
+}
+
+let author = '';
+try {
+  author = execSync('git config user.name', { encoding: 'utf8' }).trim();
+} catch (e) { /* no git identity; leave blank */ }
+
+const today = new Date().toISOString().slice(0, 10);
+
+// Include the entry text as an HTML comment so it's visible while writing but
+// never rendered on the page.
+// JSON.stringify yields a valid YAML double-quoted scalar, so titles that
+// contain colons (e.g. "Question 1: ...") don't break frontmatter parsing.
+const scaffold = `---
+title: ${JSON.stringify(entry.title || '')}
+subtitle: ""
+author: ${JSON.stringify(author)}
+date: ${today}
+---
+
+<!-- Entry: ${entry.title || entryId}
+${(entry.text || '').trim()}
+-->
+
+Write your commentary here.
+`;
+
+fs.writeFileSync(filePath, scaffold);
+
+const urlPath = `/${slug}/${segments.join('/')}`;
+console.log(`\n✔ Created ${path.relative(process.cwd(), filePath)}`);
+console.log(`  Entry:   ${entry.title || entryId}`);
+console.log(`  Preview: http://localhost:1517${urlPath}\n`);


### PR DESCRIPTION
## Summary

Adds a lightweight, file-based system for writing long-form commentary ("blog posts") about individual confession/catechism entries, rendered server-side so the content is indexable.

- **Authoring:** drop a markdown file at `content/commentary/<entry-id>.md` (e.g. `WSC-1.md`, `WCoF-1-2.md`, `CoD-1-articles-1.md`) with `title`/`subtitle`/`author`/`date` frontmatter and a markdown body.
- **Rendering:** posts are read at **build time** in `getStaticProps` and rendered on the entry page below the confession text. Entries without a file are unchanged. Because reads happen at build time, there's no serverless file-tracing risk.
- **Discovery:** a `/study` index lists all posts and links to their entry pages; `/study` is added to the sitemap. When a post exists, its `subtitle` is preferred as the page's meta description.
- **Tooling:** `npm run new-post` scaffolds the correctly-named file from a reader-facing URL or slug + segments (the internal entry id is non-obvious), validating the entry exists.

## Files

- `content/commentary/WSC-1.md` — sample post
- `lib/commentary.js` — `loadCommentary()` / `listCommentaryIds()` (build-time reads)
- `components/Commentary.jsx` — markdown renderer (`react-markdown` + `remark-gfm`)
- `pages/[confession]/[...entry].jsx` — renders the post; prefers its subtitle as meta description
- `pages/study.jsx` — browsable index
- `pages/sitemap.xml.jsx` — include `/study`
- `scripts/new-post.js` + `new-post` npm alias — file generator
- `.gitignore` — ignore `coverage/` and `*.tsbuildinfo`
- deps: `react-markdown`, `remark-gfm`, `gray-matter`

## Test plan

- [x] `/westminster-shorter-catechism/1` renders the sample post server-side (verified in raw HTML)
- [x] An entry without a post (`/westminster-shorter-catechism/2`) is unchanged
- [x] `/study` (200) lists the post and links to the entry
- [x] Entry meta description uses the post subtitle when present
- [x] `/study` appears in `sitemap.xml`
- [x] `new-post` script resolves every id shape (single, two-level, dashed Canons-of-Dort), handles bad slug / nonexistent entry / overwrite guard, and its frontmatter parses through the real loader
- [ ] Add a header nav link to `/study` (follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)