### PR TITLE
Thread domain-type JSDoc through helpers, components, and lib

### DIFF
--- a/components/BibleTextResult.jsx
+++ b/components/BibleTextResult.jsx
@@ -9,6 +9,10 @@ import {
 } from '../helpers';
 import { confessionCitationByIndex } from '../dataMapping';
 
+/**
+ * @param {object} props
+ * @param {ContentById} props.contentById
+ */
 const BibleTextResult = ({
   contentById,
   bibleText,

--- a/components/ConfessionChapterResult.jsx
+++ b/components/ConfessionChapterResult.jsx
@@ -18,6 +18,10 @@ import { getConfessionalAbbreviationId } from '../scripts/helpers';
 import { generateLink } from '../helpers';
 import { facetNamesByCanonicalDocId } from '../dataMapping';
 
+/**
+ * @param {object} props
+ * @param {ContentById} props.contentById
+ */
 const ConfessionChapterResult = ({
   docId = null,
   chapterId = null,

--- a/components/ConfessionTextResult.jsx
+++ b/components/ConfessionTextResult.jsx
@@ -25,6 +25,7 @@ const getQueryParams = (bibleText) => queryString.stringify({
 const MINIMUM_TEXT_LENGTH = 100;
 
 // return next position in confession
+/** @param {string} id @param {ContentById} contentById @param {string[]} searchTerms @param {number} direction @returns {string} */
 const getNextConfessionId = (id, contentById, searchTerms, direction = 1) => {
   const isArticle = searchTerms.some((str) => regexV2.test(str) && str.split('.').length >= 3);
   const fragments = id.split('-');
@@ -45,6 +46,10 @@ const getNextConfessionId = (id, contentById, searchTerms, direction = 1) => {
   return `${fragments[0]}-${nextChapterId}`;
 };
 
+/**
+ * @param {object} props
+ * @param {ContentById} props.contentById
+ */
 const ConfessionTextResult = ({
   contentById,
   searchTerms,

--- a/components/DocumentResultGroup.jsx
+++ b/components/DocumentResultGroup.jsx
@@ -17,6 +17,10 @@ import ConfessionTextResult from './ConfessionTextResult';
 // the match is a whole chapter) or ConfessionTextResult (a single entry) per
 // result. Shared by the homepage search results and the per-entry pages, so
 // both surfaces stay visually and behaviorally identical.
+/**
+ * @param {object} props
+ * @param {ContentById} props.contentById
+ */
 const DocumentResultGroup = ({
   documentTitle,
   results,

--- a/helpers/index.js
+++ b/helpers/index.js
@@ -84,6 +84,7 @@ export const generateCanonicalEntryLink = (confessionId) => {
 // search link when the target id is a real leaf entry with its own static
 // page - this avoids a redundant client-side Algolia search just to move to
 // the contiguous next/previous entry, since the canonical page needs none.
+/** @param {string} confessionId @param {ContentById} contentById @returns {string} */
 export const generateNavLink = (confessionId, contentById) => {
   const target = contentById[confessionId];
   if (target && !target.isParent) {
@@ -409,6 +410,7 @@ export const groupContentByChapter = (content) => groupBy(content, (obj) => {
   return obj.parent;
 });
 
+/** @param {string} confessionId @param {ContentById} contentById @returns {boolean} */
 export const isChapter = (confessionId, contentById) => (
   // parent would then be the document
   confessionId.split('-').length === 2

--- a/lib/catechisms.js
+++ b/lib/catechisms.js
@@ -133,12 +133,14 @@ export const CATECHISMS = Object.fromEntries(
   }),
 );
 
+/** @param {string} id @returns {Catechism | null} */
 export const getCatechismById = (id) => {
   const upperCaseId = id?.toUpperCase();
   if (upperCaseId === 'CFYC') return CATECHISMS.CFYC;
   return CATECHISMS[upperCaseId] || null;
 };
 
+/** @param {string} id @returns {CreedalDocument | null} */
 export const getDocumentById = (id) => {
   if (!id) return null;
   const upperCaseId = id.toUpperCase();

--- a/types/domain.d.ts
+++ b/types/domain.d.ts
@@ -88,8 +88,8 @@ interface Commentary {
  * The return type of helpers.parseFacets(). Each element is an Algolia
  * facetFilter string like "id:WCoF-1-2" or "document:...". A NESTED array of
  * strings expresses OR between those filters (Algolia's facetFilters
- * semantics); a bare string is an AND term. See the "2d array is like an OR"
- * note in helpers/index.js.
+ * semantics); a bare string is an AND term. See the parseFacets note in
+ * helpers/index.js.
  */
 type FacetFilter = string | string[];
 type FacetFilters = FacetFilter[];


### PR DESCRIPTION
## What

Follow-on to #38. Now that `types/domain.d.ts` defines the core data shapes, thread JSDoc annotations through the code so editors surface those types everywhere the shapes flow — not just at the loader boundary. Two commits:

1. **Fix stale parseFacets reference in domain types** — the `FacetFilters` doc comment still pointed at the old "2d array is like an OR" note that #38 rewrote into a proper `parseFacets` explanation. Repointed so it no longer dangles.
2. **Propagate domain-type JSDoc through helpers, components, and lib**:
   - `helpers`: `generateNavLink`, `isChapter` (`ContentById` params)
   - `ConfessionTextResult`: `getNextConfessionId` (`ContentById` param) + the component's `contentById` prop
   - `BibleTextResult`, `ConfessionChapterResult`, `DocumentResultGroup`: the `contentById` prop
   - `catechisms`: `getCatechismById` → `Catechism`, `getDocumentById` → `CreedalDocument`

## Why

The types existed but weren't referenced anywhere the data actually flows, so hovers/autocomplete in the components and helpers still showed `any`. This makes the documented shapes visible at the call sites that matter.

## Reviewer notes

- **Comment-only** — no runtime or build behavior changes. There's no `checkJs`/typecheck step, so these annotations are purely editor-surfaced.
- Component props are typed via `@param props.contentById` (documenting just the domain-typed prop) rather than a full object-literal type, to avoid falsely claiming the complete prop set.
- All 29 tests pass. The `content-routes.test.js` suite-load failure is the same pre-existing `react-markdown` ESM/Jest issue noted in #38, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)